### PR TITLE
Increment flash write address and correct write size

### DIFF
--- a/mcux/README
+++ b/mcux/README
@@ -239,3 +239,10 @@ Patch List:
    - This patch is in hal_nxp but is not in mcux-sdk-ng 25.09.00.
      This patch was merged after PR https://github.com/zephyrproject-rtos/hal_nxp/pull/612/commits was created, so it
      did not enter PR#612 via cherry-pick but rather via rebasing onto the master branch.
+
+  - hal/nxp: s32K344: flash_c40: add C40 features, IP aliases
+   - Commit: https://github.com/zephyrproject-rtos/hal_nxp/pull/618/commits/be2df903f5a0365e7549ade63b79ac831f66db6f
+   - This patch is in hal_nxp but is not in mcux-sdk-ng 25.09.00.
+     This patch was merged after PR https://github.com/zephyrproject-rtos/hal_nxp/pull/618/commits was created.
+     Also since the additions about C40 Flash geometry in S32K344_features.h and defining local Flash Aliases in
+     S32K344_glue_mcux.h, are for S32K344 SoC so they are not present in the mcusdk-core repo.

--- a/mcux/mcux-sdk-ng/drivers/flash_c40/fsl_c40_flash.c
+++ b/mcux/mcux-sdk-ng/drivers/flash_c40/fsl_c40_flash.c
@@ -818,7 +818,7 @@ status_t FLASH_Erase(flash_config_t *config, uint32_t start, uint32_t lengthInBy
 
 status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, uint32_t lengthInBytes)
 {
-    status_t ret;
+    status_t ret = kStatus_FLASH_Success;
     size_t chunkSize;
     size_t sizeLeft = lengthInBytes;
     uint8_t *src8 = (uint8_t *) src;

--- a/mcux/mcux-sdk-ng/drivers/flash_c40/fsl_c40_flash.c
+++ b/mcux/mcux-sdk-ng/drivers/flash_c40/fsl_c40_flash.c
@@ -839,7 +839,7 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
 
         chunkSize = (sizeLeft > bytesToAlignedPage) ? bytesToAlignedPage : sizeLeft;
 
-        ret = C40_Write(start, lengthInBytes, src8, C40_DEFAULT_CORE_DOMAIN_ID);
+        ret = C40_Write(addr, chunkSize, src8, C40_DEFAULT_CORE_DOMAIN_ID);
         if (ret != kStatus_FLASH_Success)
         {
             return ret;
@@ -847,6 +847,7 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
 
         sizeLeft -= chunkSize;
         src8     += chunkSize;
+        addr     += chunkSize;
     }
 
     /* continue with aligned writes */
@@ -856,7 +857,7 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
 
         chunkSize = (sizeLeft > C40_WRITE_SIZE_MAX) ? C40_WRITE_SIZE_MAX : sizeLeft;
 
-        ret = C40_Write(start, lengthInBytes, src8, C40_DEFAULT_CORE_DOMAIN_ID);
+        ret = C40_Write(addr, chunkSize, src8, C40_DEFAULT_CORE_DOMAIN_ID);
         if (ret != kStatus_FLASH_Success)
         {
             return ret;
@@ -864,6 +865,7 @@ status_t FLASH_Program(flash_config_t *config, uint32_t start, uint32_t *src, ui
 
         sizeLeft -= chunkSize;
         src8     += chunkSize;
+        addr     += chunkSize;
     }
 
     return ret;

--- a/s32/mcux/devices/S32K344/S32K344_features.h
+++ b/s32/mcux/devices/S32K344/S32K344_features.h
@@ -236,4 +236,13 @@
 /* @brief Memory map has offset between subsystems. */
 #define FSL_FEATURE_MEMORY_HAS_ADDRESS_OFFSET (1)
 
+/* FLASH Module features */
+
+/* @brief Code flash (PFLASH) implemented as 1 MiB blocks */
+#define FSL_FEATURE_FLASH_C40_BLOCK_SIZE_CODE     (1024u * 1024u)
+/* @brief Code flash (PFLASH) has 4 blocks of 1 MiB each total size = 4 MiB */
+#define FSL_FEATURE_FLASH_C40_BLOCK_COUNT_CODE    (4u)
+/* @brief Data flash (DFLASH) window: 256 KiB */
+#define FSL_FEATURE_FLASH_C40_BLOCK_SIZE_DATA     (256u * 1024u)
+
 #endif /* _S32K344_FEATURES_H_ */

--- a/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
+++ b/s32/mcux/devices/S32K344/S32K344_glue_mcux.h
@@ -208,4 +208,24 @@
 #define FLEXIO_BASE_PTRS                        IP_FLEXIO_BASE_PTRS
 /** Interrupt vectors for the FLEXIO peripheral type */
 #define FLEXIO_IRQS                              { FLEXIO_IRQn }
+
+/* FLASH - Peripheral instance base addresses */
+/** Peripheral FLASH base address */
+#define FLASH_BASE                               IP_FLASH_BASE
+/** Peripheral FLASH base pointer */
+#define FLASH                                    IP_FLASH
+/** Array initializer of FLASH peripheral base addresses */
+#define FLASH_BASE_ADDRS                         IP_FLASH_BASE_ADDRS
+/** Array initializer of FLASH peripheral base pointers */
+#define FLASH_BASE_PTRS                          IP_FLASH_BASE_PTRS
+
+/* PFLASH - Peripheral instance base addresses */
+/** Peripheral PFLASH base address */
+#define PFLASH_BASE                              IP_PFLASH_BASE
+/** Peripheral PFLASH base pointer */
+#define PFLASH                                   IP_PFLASH
+/** Array initializer of PFLASH peripheral base addresses */
+#define PFLASH_BASE_ADDRS                        IP_PFLASH_BASE_ADDRS
+/** Array initializer of PFLASH peripheral base pointers */
+#define PFLASH_BASE_PTRS                         IP_PFLASH_BASE_PTRS
 #endif  /* _S32K344_GLUE_MCUX_H_ */


### PR DESCRIPTION
This bug was discovered while testing serial DFU with MCUBoot on the branch `c40_flash_hal_nxp_1`. These changes allow serial DFU to complete successfully.

Without this fix serial DFU hangs indefinitely.