### PR TITLE
s32: drivers: s32k3: mcl: fix emios mcl ip init

### DIFF
--- a/s32/drivers/s32k3/Mcl/src/Emios_Mcl_Ip.c
+++ b/s32/drivers/s32k3/Mcl/src/Emios_Mcl_Ip.c
@@ -104,6 +104,8 @@ eMIOS_Type *const Emios_Ip_paxBase[eMIOS_INSTANCE_COUNT] = IP_eMIOS_BASE_PTRS;
     #define MCL_STOP_SEC_VAR_CLEARED_UNSPECIFIED_NO_CACHEABLE
     #include "Mcl_MemMap.h"
 
+    static boolean Emios_Ip_GlobalStateInitialized = FALSE;
+
 #endif
 
 
@@ -173,6 +175,17 @@ Emios_Ip_CommonStatusType Emios_Mcl_Ip_Init(uint8 Instance, const Emios_Mcl_Ip_C
     uint8 coreID = (uint8)OsIf_GetCoreID();
     if ( MULTICORE_INIT_CORE == coreID )
     {
+#else
+    /* Initialize Emios_Ip_axIpIsInitialized on first call (NO_CACHEABLE sections don't support static init) */
+    if (Emios_Ip_GlobalStateInitialized == FALSE)
+    {
+        for (uint8 idx = 0; idx < eMIOS_INSTANCE_COUNT; idx++)
+        {
+            Emios_Ip_axIpIsInitialized[idx].instanceInitState = FALSE;
+            /* Emios_Ip_axIpIsInitialized[idx].runCore not initialized as it is only used when STD_ON == EMIOS_IP_MULTICORE_IS_AVAILABLE. */
+        }
+        Emios_Ip_GlobalStateInitialized = TRUE;
+    }
 #endif /* STD_ON == EMIOS_IP_MULTICORE_IS_AVAILABLE */
 
         if (Emios_Ip_axIpIsInitialized[Instance].instanceInitState == TRUE)


### PR DESCRIPTION
Due to using VAR_SEC_NOCACHE before declaring Emios_Ip_axIpIsInitialized when EMIOS_IP_MULTICORE_IS_AVAILABLE is not STD_ON, the Emios_Ip_axIpIsInitialized struct can't be initialized statically. To initialize Emios_Ip_axIpIsInitialized only one time when the init function is called, a static boolean flag is used such that initializing the values within Emios_Ip_axIpIsInitialized occurs once. Further during the initialization of Emios_Ip_axIpIsInitialized, only the instanceInitState is set to an initial value, as runCore is not in the structure for this specific condition.

Signed-of-by: Tori Koelewyn <tori.koelewyn@gmail.com>

Without intiializing the Emios_Ip_axIpIsInitialized structure, there are non-zero values assigned to the instanceInitState which prevents the emios_mcl_init from actually initialziing 3 emios instances on the s32k3 board. 